### PR TITLE
Added ability to automatically copy the tree

### DIFF
--- a/src/program.ts
+++ b/src/program.ts
@@ -56,7 +56,7 @@ Links:
 
       spinner.succeed('ASCII Tree generated');
 
-      if(options.autoCopy) {
+      if(options.copy) {
         await clipboardy.write(asciiTree);
         log.success('ASCII Tree automatically copied to clipboard.');
         return;

--- a/src/program.ts
+++ b/src/program.ts
@@ -14,6 +14,7 @@ const DEPTH = '5'; // string because Commander expects a string
 const STYLE: Style = 'arrows';
 const ALL = false;
 const DIRS_FIRST = false;
+const AUTO_COPY = false;
 
 program
   .option(
@@ -27,6 +28,11 @@ program
     '-s, --style <style>',
     'Style of generated tree ("arrows" | "pipes")',
     STYLE
+  )
+  .option(
+    '-c, --copy',
+    'Automatically copy the generated tree to clipboard',
+    AUTO_COPY
   )
   .addHelpText(
     'afterAll',
@@ -49,6 +55,12 @@ Links:
       log.normal(asciiTree);
 
       spinner.succeed('ASCII Tree generated');
+
+      if(options.autoCopy) {
+        await clipboardy.write(asciiTree);
+        log.success('ASCII Tree automatically copied to clipboard.');
+        return;
+      }
 
       const answer = await promptToCopyToClipboard();
       if (answer.toLowerCase() === 'yes') {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,5 +5,5 @@ export interface Options {
   depth: string;
   style: Style;
   dirsFirst: boolean;
-  autoCopy: boolean;
+  copy: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,5 +4,6 @@ export interface Options {
   all: boolean;
   depth: string;
   style: Style;
-  dirsFirst: boolean
+  dirsFirst: boolean;
+  autoCopy: boolean;
 }


### PR DESCRIPTION
# Pull Request

## Description

This PR adds the ability to automatically copy the tree by using the `--copy` CLI argument.

## Related Issue

- N/A

## Changes Made

- Added a `--copy` / `-c` argument.
- Returns a slightly different message when automatically copied.

## Testing

- I don't have bun installed, so I cannot properly test.

## Screenshots (if applicable)

- N/A

## Checklist

Please ensure that your pull request meets the following requirements:

- [x] The code follows the project's coding conventions and style guide.
- [x] Tests have been added or updated to cover the changes (if applicable).
- [x] Documentation has been updated (if necessary).
- [x] The pull request title is descriptive.
- [x] The pull request description explains the purpose and context of the changes.

## Additional Notes

I added this because I have a shell alias called `tree` that runs this, and I'd like to always copy the output.
